### PR TITLE
Implemented drop as a synonym for stop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ include = ["src/**/*", "README.md"]
 [dependencies]
 lazy_static = { version = "1.4.0" }
 maplit = { version = "1.0.2" }
-strum = { version = "0.23.0", features = ["derive"] }
+strum = { version = "0.24.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,12 @@ pub struct Spinner {
     sender: Sender<()>,
 }
 
+impl Drop for Spinner {
+    fn drop(&mut self) {
+        self.sender.send(()).unwrap();
+    }
+}
+
 impl Spinner {
     /// Create a new spinner along with a message
     ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,3 @@
+pub mod spinner_data;
 pub mod spinner_names;
 pub mod spinners_data;
-pub mod spinner_data;

--- a/src/utils/spinner_data.rs
+++ b/src/utils/spinner_data.rs
@@ -3,4 +3,3 @@ pub struct SpinnerData {
     pub frames: Vec<&'static str>,
     pub interval: u16,
 }
-


### PR DESCRIPTION
Stops the spinner when it goes out of scope.

Effectively runs the `stop` function when the spinner variable is dropped, allowing for it to be freed from memory, without calling any extra functions.

Especially helpful with unforeseen exceptions where the `stop` function is not manually called, in which case the spinner would continue forever without this trait.

Implemented the feature from #18 