### PR TITLE
Stop printing after calling `stop` (Fixes #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 fn main() {
-    let sp = Spinner::new(Spinners::Dots9, "Waiting for 3 seconds".into());
+    let mut sp = Spinner::new(Spinners::Dots9, "Waiting for 3 seconds".into());
     sleep(Duration::from_secs(3));
     sp.stop();
 }

--- a/examples/cycle.rs
+++ b/examples/cycle.rs
@@ -5,7 +5,7 @@ use strum::IntoEnumIterator;
 fn main() {
     // loop through each spinner and display them for 2 seconds
     for spinner in Spinners::iter() {
-        let sp = Spinner::new(spinner.clone(), format!("{:?}", spinner));
+        let mut sp = Spinner::new(spinner.clone(), format!("{:?}", spinner));
         sleep(Duration::from_secs(2));
         sp.stop();
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -5,7 +5,7 @@ fn main() {
     let mut args = env::args();
     let spinner_name = args.nth(1).unwrap_or_else(|| "Dots9".to_string());
 
-    let sp = Spinner::new(
+    let mut sp = Spinner::new(
         Spinners::from_str(&spinner_name).unwrap(),
         "Waiting for 3 seconds".into(),
     );

--- a/examples/stop_symbol.rs
+++ b/examples/stop_symbol.rs
@@ -5,7 +5,7 @@ fn main() {
     let mut args = env::args();
     let spinner_name = args.nth(1).unwrap_or_else(|| "Dots9".to_string());
 
-    let sp = Spinner::new(
+    let mut sp = Spinner::new(
         Spinners::from_str(&spinner_name).unwrap(),
         "Waiting for 3 seconds".into(),
     );

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -5,7 +5,7 @@ fn main() {
     let mut args = env::args();
     let spinner_name = args.nth(1).unwrap_or_else(|| "Dots9".to_string());
 
-    let sp = Spinner::with_timer(
+    let mut sp = Spinner::with_timer(
         Spinners::from_str(&spinner_name).unwrap(),
         "Waiting for 3 seconds".into(),
     );


### PR DESCRIPTION
To consistently stop printing after a call to `stop` and it's variants,
we must join the spawned thread. To support the implementation of the
`Drop` Trait, we store the `JoinHandle` as an Option in the `Spinner`
struct. This allows us to explicitly join the thread when the Spinner is
dropped if it hasn't been explicitly stopped, otherwise it does nothing.

Fixes #26 