### PR TITLE
Updated stop_inner (fixes #2)

### DIFF
--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -10,5 +10,5 @@ fn main() {
         "Waiting for 3 seconds".into(),
     );
     sleep(Duration::from_secs(3));
-    sp.stop_with_newline();
+    sp.stop();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,5 +215,6 @@ impl Spinner {
             .send((stop_time, stop_symbol))
             .expect("Could not stop spinner thread.");
         self.join.take().unwrap().join().unwrap();
+        println!("\x1b[2K\r");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,12 +104,14 @@ impl Spinner {
     ///
     /// Stops the spinner that was created with the [`Spinner::new`] function.
     ///
-    /// Optionally call [`stop_with_newline`] to print a newline after the spinner is stopped,
-    /// or the [`stop_with_message`] function to print a message after the spinner is stopped.
+    /// Optionally call the [`stop_with_message`] function to print a message after the spinner is stopped.
+    /// You can also call the [`stop_with_symbol`] function to print a symbol after the spinner is stopped.
+    /// If you want to change the symbol and message after the spinner is stopped, you can call the [`stop_and_persist`] function.
     ///
     /// [`Spinner::new`]: struct.Spinner.html#method.new
-    /// [`stop_with_newline`]: struct.Spinner.html#method.stop_with_newline
     /// [`stop_with_message`]: struct.Spinner.html#method.stop_with_message
+    /// [`stop_with_symbol`]: struct.Spinner.html#method.stop_with_symbol
+    /// [`stop_and_persist`]: struct.Spinner.html#method.stop_and_persist
     ///
     /// # Examples
     ///
@@ -156,24 +158,6 @@ impl Spinner {
         println!();
     }
 
-    /// Stops the spinner and prints a new line
-    ///
-    /// # Examples
-    ///
-    /// Basic Usage:
-    ///
-    /// ```
-    /// use spinners::{Spinner, Spinners};
-    ///
-    /// let mut sp = Spinner::new(Spinners::Dots, "Loading things into memory...".into());
-    ///
-    /// sp.stop_with_newline();
-    /// ```
-    pub fn stop_with_newline(&mut self) {
-        self.stop();
-        println!();
-    }
-
     /// Stops the spinner and prints the provided message
     ///
     /// # Examples
@@ -189,7 +173,7 @@ impl Spinner {
     /// ```
     pub fn stop_with_message(&mut self, msg: String) {
         self.stop();
-        println!("\x1b[2K\r{}", msg);
+        println!("{}", msg);
     }
 
     /// Stops the spinner with a provided symbol and message
@@ -207,7 +191,7 @@ impl Spinner {
     /// ```
     pub fn stop_and_persist(&mut self, symbol: &str, msg: String) {
         self.stop();
-        println!("\x1b[2K\r{} {}", symbol, msg);
+        println!("{} {}", symbol, msg);
     }
 
     fn stop_inner(&mut self, stop_time: Instant, stop_symbol: Option<String>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ impl Spinner {
             .send((stop_time, stop_symbol))
             .expect("Could not stop spinner thread.");
         self.join.take().unwrap().join().unwrap();
+        // One problem I found is that there is a newline after the spinner stops.
         println!("\x1b[2K\r");
     }
 }


### PR DESCRIPTION
Edited `stop_inner` to delete the spinner and text when called. This also means the `stop_with_newline` function isn't necessary anymore. I also updated some documentation to include the new functions like `stop_and_persist`. 

Only problem I can't find a way to solve is that deleting the spinner and text leaves an empty line behind.