### PR TITLE
Add a configurable drop behavior for Spinner

### DIFF
--- a/examples/on_drop.rs
+++ b/examples/on_drop.rs
@@ -1,0 +1,46 @@
+use spinners::{Spinner, Spinners, StopBehavior};
+
+fn frobnicate(should_work: bool) -> Result<(), String> {
+    if should_work {
+        Ok(())
+    } else {
+        Err("Error!".to_string())
+    }
+}
+
+fn main() -> Result<(), String> {
+    // Successful variant shows the message from [Spinner::stop_with]
+    // and not the one from [Spinner::on_drop]
+    {
+        println!("Spinner that is stopped after some action is successfully performed:");
+        let mut sp = Spinner::new(Spinners::Dots, "Frobincating...".into()).on_drop(
+            StopBehavior::SymbolAndMessage(
+                "✗",
+                "Ouch, something went wrong with the Frobnicator!?".into(),
+            ),
+        );
+        frobnicate(true)?;
+        sp.stop_with(&StopBehavior::SymbolAndMessage(
+            "✔",
+            "Frobnication successful!".into(),
+        ));
+    }
+
+    // Failure variant in which the Spinner is dropped before having been explicitly
+    // stopped, the behavior passed into [Spinner::on_drop] is used.
+    {
+        println!("Spinner that never reaches a stop call because an error is hit before:");
+        let mut sp = Spinner::new(Spinners::Dots, "Frobincating...".into()).on_drop(
+            StopBehavior::SymbolAndMessage(
+                "✗",
+                "Ouch, something went wrong with the Frobnicator!?".into(),
+            ),
+        );
+        frobnicate(false)?;
+        sp.stop_with(&StopBehavior::SymbolAndMessage(
+            "✔",
+            "Frobnication successful!".into(),
+        ));
+    }
+    Ok(())
+}


### PR DESCRIPTION
This commit adds an `on_drop` method to Spinner, the method is a
"Builder method" (called on a Spinner taking ownership and returns a new
Spinner instance). The existing Spinner API therefore continue to work
as they did before with no changes to methods or their parameters.

By default, i.e. when `on_drop` is not used to set the default behavior
of a Spinner, its behavior remains the same as prior to this commit.
When `on_drop` is called on a Spinner, a new Spinner instance is
returned. If this instance is dropped without any of its `stop*` methods
having been called, then the `StopBehavior` set in the `on_drop` call is
triggered.

This change allows the following simple construction:
```
{
   let sp = Spinner::new(...).on_drop(StopBehavior::Message("Failed!");
   do_something_fallible()?;
   sp.stop_with_message("Yay, it worked);
}
```

If `do_something_fallible()` returns a `Result::Ok` the Spinner is
stopped with the "success" message. Conversely, if
`do_something_fallible()` returns a `Result::Err`, the Spinner is
stopped with the "Failed!" message when it is dropped.

All feedback is very welcome!