### PR TITLE
feat: Add OSC progress bar feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ include = ["src/**/*", "README.md"]
 lazy_static = { version = "1.4.0" }
 maplit = { version = "1.0.2" }
 strum = { version = "0.24.0", features = ["derive"] }
+
+[features]
+osc-progress = []

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ cargo run --example cycle
 cargo run --example simple
 ```
 
+## Feature flags
+
+### `osc-progress`
+
+Enables native terminal progress bar support via the [ConEmu OSC 9;4](https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC) protocol. Terminals like Ghostty, Windows Terminal, iTerm2, Kitty, and WezTerm render these as GUI progress bars in the title/tab bar. Unsupported terminals silently ignore the sequences.
+
+```toml
+[dependencies]
+spinners = { version = "4.1.0", features = ["osc-progress"] }
+```
+
+The progress bar is emitted as an indeterminate/pulsing indicator while the spinner is active, and cleared when the spinner is stopped or dropped. Sequences are only emitted when the output stream is a terminal, so piped output is unaffected.
+
+**Signal handling caveat:** If the process is killed abruptly (e.g. `SIGINT` via Ctrl+C, `SIGKILL`), the `Drop` implementation may not run and the progress bar won't be cleared. Terminals like Ghostty mitigate this with a ~15-second auto-clear timeout, but for immediate cleanup, applications should install their own signal handler that stops the spinner (e.g. by dropping it or calling `.stop()`) before exiting.
+
 ## License
 
 MIT © [François-Guillaume Ribreau](https://fgribreau.com), James Cordor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,32 @@
+/// # Feature flags
+///
+/// ## `osc-progress`
+///
+/// Enables native terminal progress bar support via the ConEmu OSC 9;4 protocol.
+/// Terminals like Ghostty, Windows Terminal, iTerm2, Kitty, and WezTerm render
+/// these as GUI progress bars in the title/tab bar. Unsupported terminals
+/// silently ignore the sequences.
+///
+/// The progress bar is emitted as an indeterminate/pulsing indicator while the
+/// spinner is active, and cleared when the spinner is stopped or dropped.
+///
+/// Sequences are only emitted when the output stream is a terminal (checked via
+/// `is_terminal()`), so piped output is unaffected.
+///
+/// **Signal handling caveat:** If the process is killed abruptly (e.g. `SIGINT`
+/// via Ctrl+C, `SIGKILL`), the `Drop` implementation may not run and the
+/// progress bar won't be cleared. Terminals like Ghostty mitigate this with a
+/// ~15-second auto-clear timeout, but for immediate cleanup, applications should
+/// install their own signal handler that calls [`Stream::osc_stop`] or emits
+/// the OSC 9;4 remove sequence (`\x1b]9;4;0\x1b\\`) before exiting.
+///
+/// Reference: <https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC>
+///
+/// ```toml
+/// [dependencies]
+/// spinners = { version = "4.1.0", features = ["osc-progress"] }
+/// ```
+
 use std::thread::JoinHandle;
 use std::time::Instant;
 use std::{
@@ -15,7 +44,7 @@ mod utils;
 pub struct Spinner {
     sender: Sender<(Instant, Option<String>)>,
     join: Option<JoinHandle<()>>,
-    stream: Stream
+    stream: Stream,
 }
 
 impl Drop for Spinner {
@@ -23,6 +52,11 @@ impl Drop for Spinner {
         if self.join.is_some() {
             self.sender.send((Instant::now(), None)).unwrap();
             self.join.take().unwrap().join().unwrap();
+            #[cfg(feature = "osc-progress")]
+            {
+                self.stream.osc_stop();
+                self.stream.osc_flush();
+            }
         }
     }
 }
@@ -95,6 +129,9 @@ impl Spinner {
 
         let stream = if let Some(stream) = stream { stream } else { Stream::default() };
 
+        #[cfg(feature = "osc-progress")]
+        stream.osc_start();
+
         let (sender, recv) = channel::<(Instant, Option<String>)>();
 
         let join = thread::spawn(move || 'outer: loop {
@@ -109,6 +146,13 @@ impl Spinner {
                 let frame = stop_symbol.unwrap_or_else(|| frame.to_string());
 
                 stream.write(&frame, &message, start_time, stop_time).expect("IO Error");
+                // Terminals like Ghostty auto-clear the OSC 9;4 progress bar after
+                // ~15 seconds of inactivity as a safety measure against apps that
+                // crash or are killed before sending the clear sequence. Re-emitting
+                // on each frame acts as a keep-alive.
+                // See: https://github.com/ghostty-org/ghostty/discussions/8823
+                #[cfg(feature = "osc-progress")]
+                stream.osc_start();
 
                 if do_stop {
                     break 'outer;
@@ -121,7 +165,7 @@ impl Spinner {
         Self {
             sender,
             join: Some(join),
-            stream
+            stream,
         }
     }
 
@@ -240,5 +284,7 @@ impl Spinner {
             .send((stop_time, stop_symbol))
             .expect("Could not stop spinner thread.");
         self.join.take().unwrap().join().unwrap();
+        #[cfg(feature = "osc-progress")]
+        self.stream.osc_stop();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@
 /// via Ctrl+C, `SIGKILL`), the `Drop` implementation may not run and the
 /// progress bar won't be cleared. Terminals like Ghostty mitigate this with a
 /// ~15-second auto-clear timeout, but for immediate cleanup, applications should
-/// install their own signal handler that calls [`Stream::osc_stop`] or emits
-/// the OSC 9;4 remove sequence (`\x1b]9;4;0\x1b\\`) before exiting.
+/// install their own signal handler that stops the spinner (e.g. by dropping it
+/// or calling `.stop()`) before exiting.
 ///
 /// Reference: <https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC>
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,32 +1,3 @@
-/// # Feature flags
-///
-/// ## `osc-progress`
-///
-/// Enables native terminal progress bar support via the ConEmu OSC 9;4 protocol.
-/// Terminals like Ghostty, Windows Terminal, iTerm2, Kitty, and WezTerm render
-/// these as GUI progress bars in the title/tab bar. Unsupported terminals
-/// silently ignore the sequences.
-///
-/// The progress bar is emitted as an indeterminate/pulsing indicator while the
-/// spinner is active, and cleared when the spinner is stopped or dropped.
-///
-/// Sequences are only emitted when the output stream is a terminal (checked via
-/// `is_terminal()`), so piped output is unaffected.
-///
-/// **Signal handling caveat:** If the process is killed abruptly (e.g. `SIGINT`
-/// via Ctrl+C, `SIGKILL`), the `Drop` implementation may not run and the
-/// progress bar won't be cleared. Terminals like Ghostty mitigate this with a
-/// ~15-second auto-clear timeout, but for immediate cleanup, applications should
-/// install their own signal handler that stops the spinner (e.g. by dropping it
-/// or calling `.stop()`) before exiting.
-///
-/// Reference: <https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC>
-///
-/// ```toml
-/// [dependencies]
-/// spinners = { version = "4.1.0", features = ["osc-progress"] }
-/// ```
-
 use std::thread::JoinHandle;
 use std::time::Instant;
 use std::{

--- a/src/utils/stream.rs
+++ b/src/utils/stream.rs
@@ -1,4 +1,14 @@
 use std::{io::{Write, stdout, stderr, Result}, time::Instant};
+#[cfg(feature = "osc-progress")]
+use std::io::IsTerminal;
+
+/// OSC 9;4 escape sequence for indeterminate/pulsing progress (state 3)
+#[cfg(feature = "osc-progress")]
+const OSC9_4_INDETERMINATE: &str = "\x1b]9;4;3\x1b\\";
+
+/// OSC 9;4 escape sequence to remove/hide progress (state 0)
+#[cfg(feature = "osc-progress")]
+const OSC9_4_REMOVE: &str = "\x1b]9;4;0\x1b\\";
 
 /// Handles the Printing logic for the Spinner
 #[derive(Default, Copy, Clone)]
@@ -77,4 +87,39 @@ impl Stream {
         }?;
         writer.flush()
     }
+
+    /// Returns whether the underlying stream is a terminal
+    #[cfg(feature = "osc-progress")]
+    pub fn is_terminal(&self) -> bool {
+        match self {
+            Self::Stderr => stderr().is_terminal(),
+            Self::Stdout => stdout().is_terminal(),
+        }
+    }
+
+    /// Emits OSC 9;4 indeterminate progress (state 3)
+    #[cfg(feature = "osc-progress")]
+    pub fn osc_start(&self) {
+        if self.is_terminal() {
+            let mut w = self.match_target();
+            let _ = write!(w, "{}", OSC9_4_INDETERMINATE);
+        }
+    }
+
+    /// Emits OSC 9;4 remove progress (state 0)
+    #[cfg(feature = "osc-progress")]
+    pub fn osc_stop(&self) {
+        if self.is_terminal() {
+            let mut w = self.match_target();
+            let _ = write!(w, "{}", OSC9_4_REMOVE);
+        }
+    }
+
+    /// Flushes the underlying stream
+    #[cfg(feature = "osc-progress")]
+    pub fn osc_flush(&self) {
+        let mut w = self.match_target();
+        let _ = w.flush();
+    }
+
 }


### PR DESCRIPTION
This fixes  #40 

I'm hiding it behind a feature, which means that you can either have progress bars on your spinners or you don't, you can't configure per-spinner. For now the Spinners were stateless, so if you killed your app you didn't have to do any work, with spinners however users of the library need to take care of dropping spinners on sigint or sigkill. Spinners will dissapear after 15 seconds without use.

https://github.com/user-attachments/assets/3bc400bc-7ffa-4458-b37e-c442b987375d

